### PR TITLE
Fix reading kubeconfig secret

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - list
+    - watch
+- apiGroups:
   - operator.kyma-project.io
   resources:
   - eventingauths

--- a/controllers/client.go
+++ b/controllers/client.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,17 +17,11 @@ func getTargetClusterClient(k8sClient client.Client, targetClusterId string) (cl
 		return nil, err
 	}
 
-	encoded := secret.Data["config"]
-	if len(encoded) == 0 {
+	kubeconfig := secret.Data["config"]
+	if len(kubeconfig) == 0 {
 		return nil, fmt.Errorf("failed to find target cluster kubeconfig in secret %s", kubeconfigSecretName)
 	}
 
-	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(encoded)))
-	n, err := base64.StdEncoding.Decode(decoded, encoded)
-	if err != nil {
-		return nil, err
-	}
-	kubeconfig := decoded[:n]
 	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 	if err != nil {
 		return nil, err

--- a/controllers/eventingauth_controller.go
+++ b/controllers/eventingauth_controller.go
@@ -67,9 +67,10 @@ func NewEventingAuthReconciler(c client.Client, s *runtime.Scheme, errorRequeueP
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=eventingauths,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=eventingauths/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=eventingauths/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=watch,list
 func (r *eventingAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Reconciling EventingAuth", "name", req.Name, "namespace", req.Namespace)
+	logger.Info("Reconciling EventingAuth")
 
 	cr, err := fetchEventingAuth(ctx, r.Client, req.NamespacedName)
 	if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers_test
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"github.com/kyma-project/eventing-auth-manager/controllers"
 	"github.com/kyma-project/eventing-auth-manager/internal/ias"
@@ -226,12 +225,12 @@ func initTargetClusterConfig() (client.Client, error) {
 
 		kubeconfig, err := adminUser.KubeConfig()
 		Expect(err).NotTo(HaveOccurred())
-		targetClusterK8sCfg = base64.StdEncoding.EncodeToString(kubeconfig)
+		targetClusterK8sCfg = string(kubeconfig)
 	} else {
 		log.Println("Using a K8s cluster with kubeconfig file: " + targetK8sCfgPath)
 		kubeconfig, err := os.ReadFile(targetK8sCfgPath)
 		Expect(err).NotTo(HaveOccurred())
-		targetClusterK8sCfg = base64.StdEncoding.EncodeToString(kubeconfig)
+		targetClusterK8sCfg = string(kubeconfig)
 
 		config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- The kubeconfig for testing was setup incorrect, that's why the implementation was wrong and needs to be adapted

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/eventing-auth-manager/issues/2