### PR TITLE
Fix flaky delete test

### DIFF
--- a/controllers/eventingauth_controller_test.go
+++ b/controllers/eventingauth_controller_test.go
@@ -72,6 +72,11 @@ var _ = Describe("EventingAuth Controller happy tests", Serial, Ordered, func() 
 			deleteKubeconfigSecret(crName)
 			// then, eventingAuth deletion should succeed
 			deleteEventingAuthAndVerify(eventingAuth)
+
+			// clean-up by recreating kubeconfig secret
+			createKubeconfigSecret(crName)
+			secret := verifySecretExistsOnTargetCluster()
+			deleteSecretOnTargetCluster(secret)
 		})
 	})
 })


### PR DESCRIPTION
Add clean-up of target cluster eventing-webhook-auth secret from kyma-system namespace. 
It was not being deleted at the end of the test.

**Related issue(s)**
#47
#46 