### PR TITLE
bump gcr.io/kubebuilder/kube-rbac-proxy to v0.14.1

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
This PR bumps the `kube-rbac-proxy` image to v0.14.1.

The origin of the image can be found [here](https://console.cloud.google.com/gcr/images/kubebuilder/global/kube-rbac-proxy).