### PR TITLE
bump the sec-scanner-config

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: eventing-auth-manager
 protecode:
-  - europe-docker.pkg.dev/kyma-project/dev/eventing-auth-manager:v20230725-6ae5684e
+  - europe-docker.pkg.dev/kyma-project/dev/eventing-auth-manager:v20230927-b5ed2832
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
bump the sec-scanner-config tag to the [latest build](https://console.cloud.google.com/artifacts/docker/kyma-project/europe/prod/eventing-auth-manager?rapt=AEjHL4MGXk1TGo3oV3Or6EfGxBgTHKEYHg4QfgPlN1wf-y_jKMDItCx2ZkOPa2qHD6gZRauYzSTpRdyoNiRK60ur5fymi-y0dg).