### PR TITLE
Update code linter job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
     uses: kyma-project/eventing-tools/.github/workflows/lint-go-reusable.yml@main
     with:
       go-version: '1.21'
-      lint-config-uri: https://raw.githubusercontent.com/kyma-project/eventing-tools/a9cc2c5524838736f3f8fd084021a0116675476d/config/lint/.golangci.yaml
+      lint-config-uri: https://raw.githubusercontent.com/kyma-project/eventing-tools/83087ca8c46e23c653dbeecffe695a5d8e350acb/config/lint/.golangci.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,48 +1,19 @@
-name: golangci-lint
+name: Lint Go code
+
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - main
   pull_request:
     branches:
-      - main
-permissions:
-  contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  pull-requests: read
+      - "main"
+      - "release-*"
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'sec-scanners-config.yaml'
+
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-      - uses: actions/checkout@v4
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.55
-          args: --timeout=5m
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+  code-linter:
+    name: "Run golangci-lint"
+    uses: kyma-project/eventing-tools/.github/workflows/lint-go-reusable.yml@main
+    with:
+      go-version: '1.21'
+      lint-config-uri: https://raw.githubusercontent.com/kyma-project/eventing-tools/a9cc2c5524838736f3f8fd084021a0116675476d/config/lint/.golangci.yaml

--- a/controllers/eventingauth_controller.go
+++ b/controllers/eventingauth_controller.go
@@ -60,7 +60,6 @@ func NewEventingAuthReconciler(c kpkgclient.Client, s *runtime.Scheme) ManagedRe
 	}
 }
 
-// TODO: Check if conditions are correctly represented
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=eventingauths,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=eventingauths/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=eventingauths/finalizers,verbs=update
@@ -112,8 +111,6 @@ func (r *eventingAuthReconciler) handleApplicationSecret(ctx context.Context, lo
 		logger.Info("Reconciliation done, Application secret already exists")
 		return kcontrollerruntime.Result{}, nil
 	}
-
-	// TODO: check if secret creation condition is also true, otherwise it never updates false secret ready condition
 
 	iasApplication, appExists := r.existingIasApplications[cr.Name]
 	if !appExists {


### PR DESCRIPTION
**Description**

Update code linter job to use the centralized linting config from the eventing-tools repository.

**Hints for reviewers**

- This PR also fixes the `godox` linter issues.
- I removed the TODOs mentioned in this file `controllers/eventingauth_controller.go` because they are no longer relevant.

**Related PRs**

- The current PR is a follow up to this [PR](https://github.com/kyma-project/eventing-tools/pull/74) which adds the needed import aliases used by the eventing-auth-manager repository.