### PR TITLE
chore: Bump Go version in mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/eventing-auth-manager
 
-go 1.21.1
+go 1.22.0
 
 require (
 	github.com/deepmap/oapi-codegen v1.16.2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

Blocked: https://github.com/kyma-project/eventing-auth-manager/pull/129#issuecomment-1956059555

**Description**

Changes proposed in this pull request:

- Bump the Go version in the mod file to `v1.22.0`.

**Related issue(s)**
none
